### PR TITLE
Fix promotion helper for multi-character piece codes

### DIFF
--- a/shogi.html
+++ b/shogi.html
@@ -258,7 +258,8 @@ function isPromoted(piece) {
 
 function promote(piece) {
     if (!isPromoted(piece)) {
-        return piece[0] + '+';
+        // Preserve the original piece letter when adding the promotion marker
+        return basePiece(piece) + '+';
     }
     return piece;
 }


### PR DESCRIPTION
## Summary
- fix promote() to append '+' without truncating piece string

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895679d2d588322af2931c5f5afc409